### PR TITLE
Implement permission checks for inventory endpoints

### DIFF
--- a/backend/src/domain/inventory_item/inventory_item.rs
+++ b/backend/src/domain/inventory_item/inventory_item.rs
@@ -1,4 +1,9 @@
-use crate::domain::{error::error::DomainError, product::variant::variant::Id as VariantId};
+use crate::domain::{
+    authorized_resource::authorized_resource::{AuthorizedResource, ResourceType},
+    error::error::DomainError,
+    product::variant::variant::Id as VariantId,
+    user::user::Id as UserId,
+};
 use crate::log_error;
 use chrono::{DateTime, Utc};
 use derive_getters::Getters;
@@ -52,6 +57,16 @@ impl InventoryItem {
             created_at,
             updated_at,
         })
+    }
+}
+
+impl AuthorizedResource for InventoryItem {
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Product
+    }
+
+    fn owner_user_id(&self) -> Option<UserId> {
+        None
     }
 }
 

--- a/backend/src/domain/inventory_level/inventory_level.rs
+++ b/backend/src/domain/inventory_level/inventory_level.rs
@@ -1,7 +1,10 @@
 use crate::{
     domain::{
-        error::error::DomainError, inventory_item::inventory_item::Id as InventoryItemId,
+        authorized_resource::authorized_resource::{AuthorizedResource, ResourceType},
+        error::error::DomainError,
+        inventory_item::inventory_item::Id as InventoryItemId,
         location::location::Id as LocationId,
+        user::user::Id as UserId,
     },
     log_error,
 };
@@ -72,6 +75,16 @@ impl InventoryLevel {
         )?;
 
         InventoryChange::new(name.to_owned(), reason.to_owned(), vec![change])
+    }
+}
+
+impl AuthorizedResource for InventoryLevel {
+    fn resource_type(&self) -> ResourceType {
+        ResourceType::Product
+    }
+
+    fn owner_user_id(&self) -> Option<UserId> {
+        None
     }
 }
 

--- a/backend/src/infrastructure/module/interactor_provider_impl.rs
+++ b/backend/src/infrastructure/module/interactor_provider_impl.rs
@@ -91,7 +91,12 @@ impl InteractorProvider<DatabaseTransaction, Arc<DatabaseConnection>> for Intera
         )))
     }
 
-    async fn provide_inventory_interactor(&self) -> Box<dyn InventoryInteractor> {
+    async fn provide_inventory_interactor(
+        &self,
+        transaction_manager: Arc<
+            dyn TransactionManager<DatabaseTransaction, Arc<DatabaseConnection>>,
+        >,
+    ) -> Box<dyn InventoryInteractor> {
         Box::new(InventoryInteractorImpl::new(
             Box::new(InventoryItemRepositoryImpl::new(ShopifyGQLClient::new(
                 self.shopify_config.clone(),
@@ -99,6 +104,7 @@ impl InteractorProvider<DatabaseTransaction, Arc<DatabaseConnection>> for Intera
             Box::new(InventoryLevelRepositoryImpl::new(ShopifyGQLClient::new(
                 self.shopify_config.clone(),
             ))),
+            Arc::new(RbacAuthorizer::new(Arc::clone(&transaction_manager))),
         ))
     }
 

--- a/backend/src/infrastructure/router/actix_router.rs
+++ b/backend/src/infrastructure/router/actix_router.rs
@@ -55,8 +55,9 @@ where
                 "/inventories",
                 web::get().to(
                     |controller: web::Data<Controller<I, T, C>>,
+                     request: actix_web::HttpRequest,
                      params: web::Query<GetInventoriesQueryParams>| async move {
-                        controller.get_inventories(params).await
+                        controller.get_inventories(request, params).await
                     },
                 ),
             )
@@ -64,9 +65,12 @@ where
                 "/inventories/quantities/sku/{sku}",
                 web::put().to(
                     |controller: web::Data<Controller<I, T, C>>,
+                     request: actix_web::HttpRequest,
                      path: web::Path<(String,)>,
                      body: web::Json<PutInventoryQuantityBySkuRequest>| async move {
-                        controller.put_inventory_quantity_by_sku(path, body).await
+                        controller
+                            .put_inventory_quantity_by_sku(request, path, body)
+                            .await
                     },
                 ),
             )

--- a/backend/src/interface/controller/get_inventories.rs
+++ b/backend/src/interface/controller/get_inventories.rs
@@ -38,10 +38,11 @@ where
         };
 
         let user = self.get_user(&request)?;
+        let transaction_manager = self.get_transaction_manager(&request)?;
 
         let interactor = self
             .interactor_provider
-            .provide_inventory_interactor()
+            .provide_inventory_interactor(transaction_manager)
             .await;
         let results = interactor
             .get_inventories_from_all_locations(user, &query)
@@ -103,7 +104,7 @@ mod tests {
             MockInteractorProvider::<DatabaseTransaction, Arc<DatabaseConnection>>::new();
         interactor_provider
             .expect_provide_inventory_interactor()
-            .return_once(move || Box::new(interactor) as Box<dyn InventoryInteractor>);
+            .return_once(move |_| Box::new(interactor) as Box<dyn InventoryInteractor>);
 
         let controller = web::Data::new(Controller::new(interactor_provider));
 

--- a/backend/src/interface/controller/get_inventories.rs
+++ b/backend/src/interface/controller/get_inventories.rs
@@ -27,6 +27,7 @@ where
     /// Get a list of inventories.
     pub async fn get_inventories(
         &self,
+        request: actix_web::HttpRequest,
         params: web::Query<GetInventoriesQueryParams>,
     ) -> impl Responder {
         let presenter = InventoryPresenterImpl::new();
@@ -36,11 +37,15 @@ where
             Err(error) => return presenter.present_get_inventories(Err(error)).await,
         };
 
+        let user = self.get_user(&request)?;
+
         let interactor = self
             .interactor_provider
             .provide_inventory_interactor()
             .await;
-        let results = interactor.get_inventories_from_all_locations(&query).await;
+        let results = interactor
+            .get_inventories_from_all_locations(user, &query)
+            .await;
 
         presenter.present_get_inventories(results).await
     }
@@ -67,7 +72,12 @@ fn validate_query_params(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
+    use crate::domain::user::user::UserInterface;
+    use crate::infrastructure::auth::idp_user::IdpUser;
+    use crate::infrastructure::db::sea_orm::sea_orm_manager::SeaOrmTransactionManager;
+    use crate::infrastructure::db::transaction_manager_interface::TransactionManager;
     use crate::infrastructure::router::actix_router;
     use crate::interface::controller::interactor_provider_interface::MockInteractorProvider;
     use crate::interface::mock::domain_mock::{mock_inventory_items, mock_inventory_level_map};
@@ -79,8 +89,9 @@ mod tests {
     use actix_http::Request;
     use actix_web::dev::{Service, ServiceResponse};
     use actix_web::web;
-    use actix_web::{http::StatusCode, test, App, Error};
-    use mockall::predicate::eq;
+    use actix_web::{http::StatusCode, test, App, Error, HttpMessage};
+    use mockall::predicate::{always, eq};
+    use sea_orm::{DatabaseConnection, DatabaseTransaction};
 
     const BASE_URL: &'static str = "/ec-extension/inventories";
 
@@ -88,7 +99,8 @@ mod tests {
         interactor: MockInventoryInteractor,
     ) -> impl Service<Request, Response = ServiceResponse, Error = Error> {
         // Configure the mocks
-        let mut interactor_provider = MockInteractorProvider::<(), ()>::new();
+        let mut interactor_provider =
+            MockInteractorProvider::<DatabaseTransaction, Arc<DatabaseConnection>>::new();
         interactor_provider
             .expect_provide_inventory_interactor()
             .return_once(move || Box::new(interactor) as Box<dyn InventoryInteractor>);
@@ -96,12 +108,24 @@ mod tests {
         let controller = web::Data::new(Controller::new(interactor_provider));
 
         // Create an application for testing
-        test::init_service(
-            App::new().app_data(controller).configure(
-                actix_router::configure_routes::<MockInteractorProvider<(), ()>, (), ()>,
-            ),
-        )
+        test::init_service(App::new().app_data(controller).configure(
+            actix_router::configure_routes::<
+                MockInteractorProvider<DatabaseTransaction, Arc<DatabaseConnection>>,
+                DatabaseTransaction,
+                Arc<DatabaseConnection>,
+            >,
+        ))
         .await
+    }
+
+    fn add_extensions(req: &Request) {
+        req.extensions_mut()
+            .insert(Arc::new(IdpUser::default()) as Arc<dyn UserInterface>);
+        req.extensions_mut()
+            .insert(Arc::new(SeaOrmTransactionManager::default())
+                as Arc<
+                    dyn TransactionManager<DatabaseTransaction, Arc<DatabaseConnection>>,
+                >);
     }
 
     #[actix_web::test]
@@ -109,8 +133,11 @@ mod tests {
         let mut interactor = MockInventoryInteractor::new();
         interactor
             .expect_get_inventories_from_all_locations()
-            .with(eq(GetInventoriesQuery::ProductId("0".to_string())))
-            .returning(|_| {
+            .with(
+                always(),
+                eq(GetInventoriesQuery::ProductId("0".to_string())),
+            )
+            .returning(|_, _| {
                 Ok((
                     mock_inventory_items(1),
                     mock_inventory_level_map(5, &"0".to_string()),
@@ -120,6 +147,8 @@ mod tests {
         let req = test::TestRequest::get()
             .uri(&format!("{BASE_URL}?product_id=0"))
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -132,6 +161,8 @@ mod tests {
         let req = test::TestRequest::get()
             .uri(&format!("{BASE_URL}?product_id="))
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -142,11 +173,13 @@ mod tests {
         let mut interactor = MockInventoryInteractor::new();
         interactor
             .expect_get_inventories_from_all_locations()
-            .returning(|_| Ok((vec![], HashMap::new())));
+            .returning(|_, _| Ok((vec![], HashMap::new())));
 
         let req = test::TestRequest::get()
             .uri(&format!("{BASE_URL}?product_id=0"))
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -157,11 +190,13 @@ mod tests {
         let mut interactor = MockInventoryInteractor::new();
         interactor
             .expect_get_inventories_from_all_locations()
-            .returning(|_| Err(DomainError::ValidationError));
+            .returning(|_, _| Err(DomainError::ValidationError));
 
         let req = test::TestRequest::get()
             .uri(&format!("{BASE_URL}?product_id=0"))
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -172,11 +207,13 @@ mod tests {
         let mut interactor = MockInventoryInteractor::new();
         interactor
             .expect_get_inventories_from_all_locations()
-            .returning(|_| Err(DomainError::SystemError));
+            .returning(|_, _| Err(DomainError::SystemError));
 
         let req = test::TestRequest::get()
             .uri(&format!("{BASE_URL}?product_id=0"))
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);

--- a/backend/src/interface/controller/interactor_provider_interface.rs
+++ b/backend/src/interface/controller/interactor_provider_interface.rs
@@ -29,7 +29,10 @@ where
     /// Provide Interactor for media.
     async fn provide_media_interactor(&self) -> Box<dyn MediaInteractor>;
     /// Provide Interactor for inventory.
-    async fn provide_inventory_interactor(&self) -> Box<dyn InventoryInteractor>;
+    async fn provide_inventory_interactor(
+        &self,
+        transaction_manager: Arc<dyn TransactionManager<T, C>>,
+    ) -> Box<dyn InventoryInteractor>;
     /// Provide Interactor for draft order.
     async fn provide_draft_order_interactor(
         &self,

--- a/backend/src/interface/controller/put_inventory_quantity_by_sku.rs
+++ b/backend/src/interface/controller/put_inventory_quantity_by_sku.rs
@@ -43,6 +43,7 @@ where
     /// Update the inventory of the specified SKU.
     pub async fn put_inventory_quantity_by_sku(
         &self,
+        request: actix_web::HttpRequest,
         path: Path<(String,)>,
         body: web::Json<PutInventoryQuantityBySkuRequest>,
     ) -> impl Responder {
@@ -90,6 +91,8 @@ where
             .map(|uri| LedgerDocumentUri::new(uri))
             .transpose()?;
 
+        let user = self.get_user(&request)?;
+
         let interactor = self
             .interactor_provider
             .provide_inventory_interactor()
@@ -97,6 +100,7 @@ where
 
         let result = interactor
             .allocate_inventory_by_sku_with_location(
+                user,
                 &sku,
                 &name,
                 &reason,
@@ -112,7 +116,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::domain::inventory_level::quantity::quantity::InventoryType;
+    use crate::domain::user::user::UserInterface;
+    use crate::infrastructure::auth::idp_user::IdpUser;
+    use crate::infrastructure::db::sea_orm::sea_orm_manager::SeaOrmTransactionManager;
+    use crate::infrastructure::db::transaction_manager_interface::TransactionManager;
     use crate::infrastructure::router::actix_router;
     use crate::interface::controller::interactor_provider_interface::MockInteractorProvider;
     use crate::interface::mock::domain_mock::mock_inventory_levels;
@@ -124,8 +134,9 @@ mod tests {
     use actix_http::Request;
     use actix_web::dev::{Service, ServiceResponse};
     use actix_web::web;
-    use actix_web::{http::StatusCode, test, App, Error};
-    use mockall::predicate::eq;
+    use actix_web::{http::StatusCode, test, App, Error, HttpMessage};
+    use mockall::predicate::{always, eq};
+    use sea_orm::{DatabaseConnection, DatabaseTransaction};
 
     const BASE_URL: &'static str = "/ec-extension/inventories/quantities/sku";
 
@@ -133,7 +144,8 @@ mod tests {
         interactor: MockInventoryInteractor,
     ) -> impl Service<Request, Response = ServiceResponse, Error = Error> {
         // Configure the mocks
-        let mut interactor_provider = MockInteractorProvider::<(), ()>::new();
+        let mut interactor_provider =
+            MockInteractorProvider::<DatabaseTransaction, Arc<DatabaseConnection>>::new();
         interactor_provider
             .expect_provide_inventory_interactor()
             .return_once(move || Box::new(interactor) as Box<dyn InventoryInteractor>);
@@ -141,12 +153,24 @@ mod tests {
         let controller = web::Data::new(Controller::new(interactor_provider));
 
         // Create an application for testing
-        test::init_service(
-            App::new().app_data(controller).configure(
-                actix_router::configure_routes::<MockInteractorProvider<(), ()>, (), ()>,
-            ),
-        )
+        test::init_service(App::new().app_data(controller).configure(
+            actix_router::configure_routes::<
+                MockInteractorProvider<DatabaseTransaction, Arc<DatabaseConnection>>,
+                DatabaseTransaction,
+                Arc<DatabaseConnection>,
+            >,
+        ))
         .await
+    }
+
+    fn add_extensions(req: &Request) {
+        req.extensions_mut()
+            .insert(Arc::new(IdpUser::default()) as Arc<dyn UserInterface>);
+        req.extensions_mut()
+            .insert(Arc::new(SeaOrmTransactionManager::default())
+                as Arc<
+                    dyn TransactionManager<DatabaseTransaction, Arc<DatabaseConnection>>,
+                >);
     }
 
     #[actix_web::test]
@@ -160,6 +184,7 @@ mod tests {
         interactor
             .expect_allocate_inventory_by_sku_with_location()
             .with(
+                always(),
                 eq(Sku::new(sku).unwrap()),
                 eq(InventoryType::Available),
                 eq(InventoryChangeReason::Correction),
@@ -167,7 +192,7 @@ mod tests {
                 eq(ledger_document_uri),
                 eq(location_id.to_string()),
             )
-            .returning(|_, _, _, _, _, _| Ok(mock_inventory_levels(1).remove(0)));
+            .returning(|_, _, _, _, _, _, _| Ok(mock_inventory_levels(1).remove(0)));
 
         let req = test::TestRequest::put()
             .uri(&format!("{BASE_URL}/{sku}"))
@@ -179,6 +204,8 @@ mod tests {
                 location_id: location_id.to_string(),
             })
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::OK);
@@ -189,7 +216,7 @@ mod tests {
         let mut interactor = MockInventoryInteractor::new();
         interactor
             .expect_allocate_inventory_by_sku_with_location()
-            .returning(|_, _, _, _, _, _| Err(DomainError::NotFound));
+            .returning(|_, _, _, _, _, _, _| Err(DomainError::NotFound));
 
         let req = test::TestRequest::put()
             .uri(&format!("{BASE_URL}/test-sku-1"))
@@ -201,6 +228,8 @@ mod tests {
                 location_id: "location_id".to_string(),
             })
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -211,7 +240,7 @@ mod tests {
         let mut interactor = MockInventoryInteractor::new();
         interactor
             .expect_allocate_inventory_by_sku_with_location()
-            .returning(|_, _, _, _, _, _| Err(DomainError::ValidationError));
+            .returning(|_, _, _, _, _, _, _| Err(DomainError::ValidationError));
 
         let req = test::TestRequest::put()
             .uri(&format!("{BASE_URL}/test-sku-1"))
@@ -223,6 +252,8 @@ mod tests {
                 location_id: "location_id".to_string(),
             })
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -233,7 +264,7 @@ mod tests {
         let mut interactor = MockInventoryInteractor::new();
         interactor
             .expect_allocate_inventory_by_sku_with_location()
-            .returning(|_, _, _, _, _, _| Err(DomainError::SystemError));
+            .returning(|_, _, _, _, _, _, _| Err(DomainError::SystemError));
 
         let req = test::TestRequest::put()
             .uri(&format!("{BASE_URL}/test-sku-1"))
@@ -245,6 +276,8 @@ mod tests {
                 location_id: "location_id".to_string(),
             })
             .to_request();
+        add_extensions(&req);
+
         let resp: ServiceResponse = test::call_service(&setup(interactor).await, req).await;
 
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);

--- a/backend/src/interface/controller/put_inventory_quantity_by_sku.rs
+++ b/backend/src/interface/controller/put_inventory_quantity_by_sku.rs
@@ -92,10 +92,11 @@ where
             .transpose()?;
 
         let user = self.get_user(&request)?;
+        let transaction_manager = self.get_transaction_manager(&request)?;
 
         let interactor = self
             .interactor_provider
-            .provide_inventory_interactor()
+            .provide_inventory_interactor(transaction_manager)
             .await;
 
         let result = interactor
@@ -148,7 +149,7 @@ mod tests {
             MockInteractorProvider::<DatabaseTransaction, Arc<DatabaseConnection>>::new();
         interactor_provider
             .expect_provide_inventory_interactor()
-            .return_once(move || Box::new(interactor) as Box<dyn InventoryInteractor>);
+            .return_once(move |_| Box::new(interactor) as Box<dyn InventoryInteractor>);
 
         let controller = web::Data::new(Controller::new(interactor_provider));
 

--- a/backend/src/usecase/interactor/inventory/inventory_impl.rs
+++ b/backend/src/usecase/interactor/inventory/inventory_impl.rs
@@ -5,6 +5,9 @@ use async_trait::async_trait;
 
 use crate::{
     domain::{
+        authorized_resource::authorized_resource::{
+            AuthorizedResource, Resource, ResourceAction, ResourceType,
+        },
         error::error::DomainError,
         inventory_item::inventory_item::{Id as InventoryItemId, InventoryItem},
         inventory_level::{
@@ -21,6 +24,7 @@ use crate::{
     },
     log_error,
     usecase::{
+        auth::authorizer_interface::Authorizer,
         interactor::inventory_interactor_interface::{GetInventoriesQuery, InventoryInteractor},
         repository::{
             inventory_item_repository_interface::InventoryItemRepository,
@@ -33,16 +37,19 @@ use crate::{
 pub struct InventoryInteractorImpl {
     inventory_item_repository: Box<dyn InventoryItemRepository>,
     inventory_level_repository: Box<dyn InventoryLevelRepository>,
+    authorizer: Arc<dyn Authorizer>,
 }
 
 impl InventoryInteractorImpl {
     pub fn new(
         inventory_item_repository: Box<dyn InventoryItemRepository>,
         inventory_level_repository: Box<dyn InventoryLevelRepository>,
+        authorizer: Arc<dyn Authorizer>,
     ) -> Self {
         Self {
             inventory_item_repository: inventory_item_repository,
             inventory_level_repository: inventory_level_repository,
+            authorizer: authorizer,
         }
     }
 }
@@ -66,6 +73,15 @@ impl InventoryInteractor for InventoryInteractorImpl {
                 let inventory_items = self
                     .inventory_item_repository
                     .find_inventory_item_by_sku(sku)
+                    .await?;
+
+                // Check authorization for inventory read access
+                self.authorizer
+                    .authorize(
+                        user.clone(),
+                        vec![&inventory_items as &dyn AuthorizedResource],
+                        &ResourceAction::Read,
+                    )
                     .await?;
 
                 let inventory_levels = self
@@ -104,6 +120,15 @@ impl InventoryInteractor for InventoryInteractorImpl {
                 );
                 DomainError::NotFound
             })?;
+
+        // Check authorization for inventory write access
+        self.authorizer
+            .authorize(
+                user.clone(),
+                vec![&inventory_level as &dyn AuthorizedResource],
+                &ResourceAction::Write,
+            )
+            .await?;
 
         let inventory_change =
             inventory_level.create_inventory_change(name, reason, delta, ledger_document_uri)?;

--- a/backend/src/usecase/interactor/inventory/inventory_impl.rs
+++ b/backend/src/usecase/interactor/inventory/inventory_impl.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 
@@ -16,6 +17,7 @@ use crate::{
         },
         location::location::Id as LocationId,
         product::variant::sku::sku::Sku,
+        user::user::UserInterface,
     },
     log_error,
     usecase::{
@@ -49,6 +51,7 @@ impl InventoryInteractorImpl {
 impl InventoryInteractor for InventoryInteractorImpl {
     async fn get_inventories_from_all_locations(
         &self,
+        user: Arc<dyn UserInterface>,
         query: &GetInventoriesQuery,
     ) -> Result<
         (
@@ -81,6 +84,7 @@ impl InventoryInteractor for InventoryInteractorImpl {
 
     async fn allocate_inventory_by_sku_with_location(
         &self,
+        user: Arc<dyn UserInterface>,
         sku: &Sku,
         name: &InventoryType,
         reason: &InventoryChangeReason,

--- a/backend/src/usecase/interactor/inventory_interactor_interface.rs
+++ b/backend/src/usecase/interactor/inventory_interactor_interface.rs
@@ -2,8 +2,10 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use mockall::automock;
+use std::sync::Arc;
 
 use crate::domain::error::error::DomainError;
+use crate::domain::user::user::UserInterface;
 use crate::domain::inventory_item::inventory_item::{Id as InventoryItemId, InventoryItem};
 use crate::domain::inventory_level::inventory_level::InventoryLevel;
 use crate::domain::inventory_level::quantity::quantity::InventoryType;
@@ -27,6 +29,7 @@ pub trait InventoryInteractor {
     ///
     /// # Arguments
     ///
+    /// * `user` - The user interface for authorization.
     /// * `query` - get inventories query
     ///
     /// # Returns
@@ -38,6 +41,7 @@ pub trait InventoryInteractor {
     /// * Returns a domain error if the media repository fails.
     async fn get_inventories_from_all_locations(
         &self,
+        user: Arc<dyn UserInterface>,
         query: &GetInventoriesQuery,
     ) -> Result<
         (
@@ -51,6 +55,7 @@ pub trait InventoryInteractor {
     ///
     /// # Arguments
     ///
+    /// * `user` - The user interface for authorization.
     /// * `sku` - sku
     /// * `name` - inventory type
     /// * `reason` - inventory change reason
@@ -67,6 +72,7 @@ pub trait InventoryInteractor {
     /// * Returns a domain error if the media repository fails.
     async fn allocate_inventory_by_sku_with_location(
         &self,
+        user: Arc<dyn UserInterface>,
         sku: &Sku,
         name: &InventoryType,
         reason: &InventoryChangeReason,


### PR DESCRIPTION
Authorization checks were added to inventory-related endpoints, mirroring the existing security patterns found in product and customer endpoints.

*   In `backend/src/interface/controller/get_inventories.rs` and `backend/src/interface/controller/put_inventory_quantity_by_sku.rs`:
    *   `HttpRequest` was added to the endpoint method signatures.
    *   The `self.get_user(&request)?` method was called to retrieve the authenticated user.
    *   The retrieved user object was then passed as a new argument to the respective interactor methods.
    *   Associated test cases were updated to include mock `HttpRequest` extensions containing user and transaction manager data, ensuring tests reflect the new authorization flow.
*   In `backend/src/usecase/interactor/inventory_interactor_interface.rs`:
    *   The `InventoryInteractor` trait methods, `get_inventories_from_all_locations` and `allocate_inventory_by_sku_with_location`, were updated to accept an `Arc<dyn UserInterface>` parameter.
*   In `backend/src/usecase/interactor/inventory/inventory_impl.rs`:
    *   The concrete implementations of these interactor methods were modified to accept the new `user` parameter.

These changes ensure that user context is propagated to the interactor layer for authorization, maintaining a consistent security model across the application.